### PR TITLE
Cli artifact sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # install-phylum-latest-action
 A GitHub Action to install the latest version of the Phylum [command-line tool](https://github.com/phylum-dev/cli).
 
-This action enables users to download, install, and configure the Phylum command-line interface (CLI) tool for use. The Phylum CLI tool allows users to submit their project package dependencies to Phylum's API for analysis. 
+This action enables users to download, install, and configure the Phylum command-line interface (CLI) tool for use.
+The Phylum CLI tool allows users to submit their project package dependencies to Phylum's API for analysis.
 
-Phylum provides a complete risk analyis of "open-source packages" (read: untrusted software from random Internet strangers). Phylum evolved forward from legacy SCA tools to defend from supply-chain malware, malicious open-source authors, and engineering risk, in addtion to software vulnerabilities and license risks. To learn more, please see [our website](https://phylum.io).
-
-
+Phylum provides a complete risk analyis of "open-source packages" (read: untrusted software from random Internet
+strangers). Phylum evolved forward from legacy SCA tools to defend from supply-chain malware, malicious open-source
+authors, and engineering risk, in addition to software vulnerabilities and license risks. To learn more, please see
+[our website](https://phylum.io).
 
 ## Features
 - can be used by other GitHub Actions to set Phylum up in the environment
 
 ## Getting Started
 This is a sample workflow using this action. Note the `export` to add the phylum install directory to your `PATH`.
+
 ```yaml
 on: [push]
 
@@ -33,9 +36,8 @@ jobs:
           phylum projects
 ```
 
-
-### Requirements:
+### Requirements
 - active Phylum account ([Register here](https://app.phylum.io/auth/registration))
 - mandatory inputs:
-  
+
   `phylum_token` - the API authentication token for your account

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ authors, and engineering risk, in addition to software vulnerabilities and licen
 - can be used by other GitHub Actions to set Phylum up in the environment
 
 ## Getting Started
-This is a sample workflow using this action. Note the `export` to add the phylum install directory to your `PATH`.
+This is a sample workflow using this action.
+<!-- TODO: Remove the export line here and in the action? It appears to already be happening in the CLI installer -->
+Note the `export` to add the phylum install directory to your `PATH`.
 
 ```yaml
 on: [push]
@@ -38,6 +40,12 @@ jobs:
 
 ### Requirements
 - active Phylum account ([Register here](https://app.phylum.io/auth/registration))
+- a Linux runner (e.g., `runs-on: ubuntu-*` for the GitHub hosted runners)
+  - technically, the runner just needs to match the `x86_64-unknown-linux-musl` Rust target
 - mandatory inputs:
-
-  `phylum_token` - the API authentication token for your account
+  - `phylum_token` - the API authentication token for your account
+- optional inputs:
+  - `phylum_version` - a specific version of the Phylum CLI to install
+    - NOTE: when not specified, the `latest` version will be installed
+    - NOTE: the Phylum CLI 1.3.0 release changed the way the artifacts are packaged and released, which means this
+            option should **NOT specify a version less than 1.3.0**

--- a/action.yml
+++ b/action.yml
@@ -11,11 +11,9 @@ inputs:
 
 runs:
   using: "composite"
-  defaults:
-    run:
-      shell: bash
   steps:
     - name: Download latest phylum release
+      shell: bash
       run: |
         echo "[*] Downloading latest release"
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-unknown-linux-musl.zip"
@@ -23,12 +21,14 @@ runs:
 
     - name: Download specific Phylum version
       if: ${{ inputs.phylum_version != '0' }}
+      shell: bash
       run: |
         echo "[*] Downloading specific version (${{ inputs.phylum_version }})"
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip.minisig "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
 
     - name: Verify the download
+      shell: bash
       run: |
         sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
         sudo apt update
@@ -36,6 +36,7 @@ runs:
         minisign -Vm ~/phylum-x86_64-unknown-linux-musl.zip -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
 
     - name: Run install script
+      shell: bash
       run: |
         unzip ~/phylum-x86_64-unknown-linux-musl.zip -d ~
         pushd "$HOME/phylum-x86_64-unknown-linux-musl" || exit 11
@@ -44,11 +45,13 @@ runs:
         echo "[*] installed phylum-cli"
 
     - name: Setup credentials
+      shell: bash
       run: |
         sed -i "5 a \  offline_access: ${{ inputs.phylum_token }}" ~/.phylum/settings.yaml
         echo "[*] Configured phylum-cli with token"
 
     - name: Test phylum
+      shell: bash
       run: |
         export PATH="$HOME/.phylum:$PATH"
         pushd $GITHUB_WORKSPACE || exit 1

--- a/action.yml
+++ b/action.yml
@@ -5,47 +5,52 @@ inputs:
     description: "Phylum user token"
     required: true
   phylum_version:
-    description: "Phylum version"
+    description: "Phylum CLI version (at least 1.3.0)"
     required: false
     default: '0'
 
 runs:
   using: "composite"
+  defaults:
+    run:
+      shell: bash
   steps:
     - name: Download latest phylum release
-      shell: bash
       run: |
         echo "[*] Downloading latest release"
-        curl -Lo ~/phylum-cli-release.zip "https://github.com/phylum-dev/cli/releases/latest/download/phylum-cli-release.zip"
+        curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-unknown-linux-musl.zip"
+        curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip.minisig "https://github.com/phylum-dev/cli/releases/latest/download/phylum-x86_64-unknown-linux-musl.zip.minisig"
 
     - name: Download specific Phylum version
       if: ${{ inputs.phylum_version != '0' }}
-      shell: bash
       run: |
         echo "[*] Downloading specific version (${{ inputs.phylum_version }})"
-        curl -Lo ~/phylum-cli-release.zip "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-cli-release.zip"
+        curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
+        curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip.minisig "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
+
+    - name: Verify the download
+      run: |
+        sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
+        sudo apt update
+        sudo apt install -yq minisign
+        minisign -Vm ~/phylum-x86_64-unknown-linux-musl.zip -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
 
     - name: Run install script
-      shell: bash
       run: |
-        unzip ~/phylum-cli-release.zip -d ~
-        export PATH="$HOME/phylum-cli-release:$PATH"
-        pushd "$HOME/phylum-cli-release" || exit 11
-          bash install.sh
+        unzip ~/phylum-x86_64-unknown-linux-musl.zip -d ~
+        pushd "$HOME/phylum-x86_64-unknown-linux-musl" || exit 11
+          bash "$HOME/phylum-x86_64-unknown-linux-musl/install.sh"
         popd
         echo "[*] installed phylum-cli"
 
     - name: Setup credentials
-      shell: bash
       run: |
         sed -i "5 a \  offline_access: ${{ inputs.phylum_token }}" ~/.phylum/settings.yaml
         echo "[*] Configured phylum-cli with token"
 
     - name: Test phylum
-      shell: bash
       run: |
         export PATH="$HOME/.phylum:$PATH"
         pushd $GITHUB_WORKSPACE || exit 1
           phylum --help
         popd
-

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
       shell: bash
       run: |
         echo "[*] Downloading specific version (${{ inputs.phylum_version }})"
-        curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
+        curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip"
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip.minisig "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
 
     #- name: Verify the download

--- a/action.yml
+++ b/action.yml
@@ -27,13 +27,13 @@ runs:
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip"
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip.minisig "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
 
-    #- name: Verify the download
-    #  shell: bash
-    #  run: |
-    #    sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
-    #    sudo apt update
-    #    sudo apt install -yq minisign
-    #    minisign -Vm ~/phylum-x86_64-unknown-linux-musl.zip -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
+    - name: Verify the download
+      shell: bash
+      run: |
+        sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
+        sudo apt update
+        sudo apt install -yq minisign
+        minisign -Vm ~/phylum-x86_64-unknown-linux-musl.zip -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
 
     - name: Run install script
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -27,13 +27,13 @@ runs:
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
         curl -Lo ~/phylum-x86_64-unknown-linux-musl.zip.minisig "https://github.com/phylum-dev/cli/releases/download/${{ inputs.phylum_version }}/phylum-x86_64-unknown-linux-musl.zip.minisig"
 
-    - name: Verify the download
-      shell: bash
-      run: |
-        sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
-        sudo apt update
-        sudo apt install -yq minisign
-        minisign -Vm ~/phylum-x86_64-unknown-linux-musl.zip -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
+    #- name: Verify the download
+    #  shell: bash
+    #  run: |
+    #    sudo add-apt-repository -y ppa:dysfunctionalprogramming/minisign
+    #    sudo apt update
+    #    sudo apt install -yq minisign
+    #    minisign -Vm ~/phylum-x86_64-unknown-linux-musl.zip -P RWT6G44ykbS8GABiLXrJrYsap7FCY77m/Jyi0fgsr/Fsy3oLwU4l0IDf
 
     - name: Run install script
       shell: bash


### PR DESCRIPTION
This PR accounts for the Phylum CLI 1.3.0 release artifact layout. Testing was performed, with @furi0us333's help, using the `TestGHA` repo.

**ACTIONS:**
* Add a step to verify the signature of the download with `minisign`
  * This is one reason the action will now only work on linux runners
* Hard code the `x86_64-unknown-linux-musl` CLI target for download
  * This is to avoid adding a new input for specifying the os/target
  * This is another reason the action will now only work on linux runners
* Update the docs
  * Make it clear the runner needs to match the `x86_64-unknown-linux-musl` Rust target

**BREAKING CHANGES:**
* Specifying a CLI version less than 1.3.0 will not work
* This action is only supported on linux runners due to the use of apt to install `minisign`