### PR TITLE
Use environment variable instead of settings.yaml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,9 +47,7 @@ runs:
     - name: Setup credentials
       shell: bash
       run: |
-        export PATH="$HOME/.phylum:$PATH"
-        phylum version
-        sed -i "s/offline_access:.*/offline_access: ${{ inputs.phylum_token }}/" ~/.phylum/settings.yaml
+        echo "PHYLUM_API_KEY=${{ inputs.phylum_token }}" >> $GITHUB_ENV
         echo "[*] Configured phylum-cli with token"
 
     - name: Test phylum


### PR DESCRIPTION
Setting the `PHYLUM_API_KEY` environment variable is equivalent to setting the `offline_access` setting in the config file. But the environment variable doesn't rely on knowing the location of the config file (which will be changing soon).

Resolves #9 