### PR TITLE
Correct CLI version numbers in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ jobs:
 - optional inputs:
   - `phylum_version` - a specific version of the Phylum CLI to install
     - NOTE: when not specified, the `latest` version will be installed
-    - NOTE: the Phylum CLI 1.3.0 release changed the way the artifacts are packaged and released, which means this
-            option should **NOT specify a version less than 1.3.0**
+    - NOTE: the Phylum CLI 2.0.0 release changed the way the artifacts are packaged and released, which means this
+            option should **NOT specify a version less than 2.0.0**

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "Phylum user token"
     required: true
   phylum_version:
-    description: "Phylum CLI version (at least 1.3.0)"
+    description: "Phylum CLI version (at least 2.0.0)"
     required: false
     default: '0'
 


### PR DESCRIPTION
Version `1.3.0` of the CLI doesn't exist. That release became `2.0.0`. This PR updates the docs to reflect that reality.