### PR TITLE
Add `phylum` to system path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ authors, and engineering risk, in addition to software vulnerabilities and licen
 
 ## Getting Started
 This is a sample workflow using this action.
-<!-- TODO: Remove the export line here and in the action? It appears to already be happening in the CLI installer -->
-Note the `export` to add the phylum install directory to your `PATH`.
 
 ```yaml
 on: [push]
@@ -34,8 +32,7 @@ jobs:
       - name: Run phylum to test auth with token
         shell: bash
         run: |
-          export PATH="$HOME/.phylum:$PATH"
-          phylum projects
+          phylum project
 ```
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - id: phylum-test
-        uses: phylum-dev/install-phylum-latest-action@master
+        uses: phylum-dev/install-phylum-latest-action@v1
         with:
           phylum_token: ${{ secrets.PHYLUM_TOKEN }}
 

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,16 @@ runs:
         popd
         echo "[*] installed phylum-cli"
 
+    - name: Update system path
+      shell: bash
+      run: |
+        # In version 2.2.0 and older, the binary is installed at "$HOME/.phylum". But newer versions use "$HOME/.local/bin"
+        if [ -f "$HOME/.phylum/phylum" -a -x "$HOME/.phylum/phylum" ]; then
+          echo "$HOME/.phylum" >> $GITHUB_PATH
+        else
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+        fi
+
     - name: Setup credentials
       shell: bash
       run: |
@@ -55,7 +65,6 @@ runs:
     - name: Test phylum
       shell: bash
       run: |
-        export PATH="$HOME/.phylum:$PATH"
         pushd $GITHUB_WORKSPACE || exit 1
           phylum --help
         popd


### PR DESCRIPTION
Github actions provide a simple way to [add to the system path](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path). This PR uses it and corrects the path in light of phylum-dev/cli#251